### PR TITLE
fix: golangci-lint crashes in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,12 +43,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
-
-      - name: Install linters
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.4.0
+          go-version: stable
 
       - name: Run golangci-lint
-        run: golangci-lint run ./...
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.1


### PR DESCRIPTION
## Description

This changes introduce fix for `golangci-lint`. Previously I'm manually installing golangci-lint, now it's using golangci-lint Github action. I have tested it locally using `act` and it works.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues

Closes #

## Changes Made

- Fix `golangci-lint` in CI

## SPEC Compliance

- [ ] This PR implements/fixes spec compliance
- [ ] Spec section(s) affected:
- [ ] Spec version: 1.3

## Testing

- [x] All existing tests pass
- [ ] Added new tests for changes
- [x] Tested on Go 1.23
- [x] Tested on Go 1.24
- [x] Tested on Go 1.25

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have added type hints to new code
- [ ] I have run `go fmt`
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation (if needed)
- [ ] My changes do not introduce new dependencies

## Additional Context

